### PR TITLE
Fix `connect-to-server` button flow

### DIFF
--- a/lib/presentation/screens/containers_screen.dart
+++ b/lib/presentation/screens/containers_screen.dart
@@ -84,20 +84,30 @@ class _ContainersScreenState extends State<ContainersScreen>
 
   Future<void> _handleServerSelection(Server server) async {
     try {
-      await _serverRepository.setLastUsedServerId(server.id);
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('connection.selected_server'.tr(args: [server.name])),
-            duration: const Duration(milliseconds: 800),
-          ),
-        );
-      }
-
       final result = await _sshService.switchToServer(server);
       if (result.success) {
+        try {
+          await _serverRepository.setLastUsedServerId(server.id);
+        } catch (e) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('connection.failed_to_set_last_used'.tr(args: [e.toString()])),
+                backgroundColor: Colors.orange,
+                duration: const Duration(seconds: 2),
+              ),
+            );
+          }
+        }
+
         if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('connection.selected_server'.tr(args: [server.name])),
+              duration: const Duration(milliseconds: 800),
+            ),
+          );
+
           setState(() {
             _lastKnownServer = server;
             _lastLoadedServerId = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.2+24
+version: 1.3.3+25
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server selection now persists your last used server and restores it on next launch

* **Improvements**
  * More robust server switching with clearer success/error feedback and streamlined loading flow

* **Chores**
  * App version updated to 1.3.3+25

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->