### PR TITLE
renable minfication for testing

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -61,10 +61,6 @@ android {
 
     buildTypes {
         release {
-            // Disable code shrinking and obfuscation to prevent Play Store optimization issues
-            isMinifyEnabled = false
-            isShrinkResources = false
-            
             // Use release keystore if available, otherwise fall back to debug
             val keystorePropertiesFile = rootProject.file("keystore.properties")
             println("🔍 Looking for keystore.properties at: ${keystorePropertiesFile.absolutePath}")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
     
     <application
         android:label="Docker Manager"
-        android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher"
-        android:extractNativeLibs="true">
+        android:name="${applicationName}">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
- minification was disabled because it was suspected to be the cause of the black screen issue
- we found the reason was using `Connect to server` from home screen because the flow of that button was popping the base screen twice, leading to black screen
- disabling minification has increased the size of app by 2 MB and I suspect it has nothing to do with black screen now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Android build configuration to enable automatic code and resource compression, potentially reducing app size and improving performance
  * Streamlined application manifest by removing unused attributes for cleaner builds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->